### PR TITLE
Receipt UX & other improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,6 +101,7 @@
   },
   "dependencies": {
     "@glif/filecoin-address": "^1.1.0-beta.18",
+    "@types/lodash": "^4.14.168",
     "axios": "^0.21.1",
     "base32-decode": "^1.0.0",
     "blakejs": "^1.1.0",
@@ -108,6 +109,7 @@
     "buffer": "^6.0.3",
     "ipld-dag-cbor": "^0.18.0",
     "leb128": "^0.0.5",
+    "lodash": "^4.17.21",
     "lowercase-keys": "^2.0.0",
     "noble-bls12-381": "^0.9.0",
     "stream": "^0.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webnative-filecoin",
-  "version": "0.3.2",
+  "version": "0.4.0",
   "description": "Fission Webnative Filecoin SDK",
   "keywords": [],
   "main": "dist/index.cjs.js",

--- a/src/client.ts
+++ b/src/client.ts
@@ -6,7 +6,7 @@ const API_URL = process.env.NODE_ENV === 'development'
   ? 'http://localhost:3000/api/v1/filecoin'
   : 'https://cosigner.runfission.com/api/v1/filecoin'
 
-export const cosignMessage = async (message: SignedMessage): Promise<CID> => {
+export const cosignMessage = async (message: SignedMessage): Promise<Receipt> => {
   const resp = await axios.post(`${API_URL}/message`, { message })
   return resp.data
 }
@@ -28,6 +28,11 @@ export const getWalletInfo = async (publicKey: string): Promise<WalletInfo> => {
 
 export const getProviderAddress = async (): Promise<Address> => {
   const resp = await axios.get(`${API_URL}/provider/address`)
+  return resp.data
+}
+
+export const getProviderBalance = async (pubkey: string): Promise<number> => {
+  const resp = await axios.get(`${API_URL}/provider/balance/${pubkey}`)
   return resp.data
 }
 
@@ -56,7 +61,18 @@ export const waitForReceipt = async (messageId: string): Promise<Receipt> => {
   return resp.data
 }
 
-export const getPastReciepts = async (publicKey: string): Promise<any> => {
+export const getPastReciepts = async (publicKey: string): Promise<Receipt[]> => {
   const resp = await axios.get(`${API_URL}/receipts/${publicKey}`)
   return resp.data
 }
+
+export const getMessageStatus = async (messageId: CID): Promise<Receipt> => {
+  const resp = await axios.get(`${API_URL}/message/${messageId}`)
+  return resp.data
+}
+
+export const getBlockHeight = async (): Promise<number> => {
+  const resp = await axios.get(`${API_URL}/blockheight`)
+  return resp.data.height
+}
+

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -3,6 +3,7 @@ export type Address = string
 export type WalletInfo = {
   address: string
   balance: number 
+  providerBalance: number
 }
 
 export type SignedMessage = {
@@ -45,6 +46,10 @@ export type Receipt = {
   to: Address
   amount: number
   time: number
-  blockheight: number
+  blockheight: number | null
   status: MessageStatus
+}
+
+export type CompletedReceipt = Receipt & {
+  blockheight: number
 }

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,3 +1,5 @@
+import { Receipt } from "./types"
+
 export const filToAttoFil = (amount: number): string => {
   const attoAmount = BigInt(amount * 1000) * BigInt(1000000000000000)
   return attoAmount.toString()
@@ -5,4 +7,14 @@ export const filToAttoFil = (amount: number): string => {
 
 export const attoFilToFil = (amount: string): number => {
   return Number(BigInt(amount) / BigInt(1000000000000000)) / 1000
+}
+
+export const wait = async (time: number): Promise<void> => {
+  return new Promise((resolve) => {
+    setTimeout(resolve, time)
+  })
+}
+
+export const mostRecent = (a: Receipt, b: Receipt): number => {
+  return a.time - b.time
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1257,6 +1257,11 @@
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.7.tgz#98a993516c859eb0d5c4c8f098317a9ea68db9ad"
   integrity sha512-cxWFQVseBm6O9Gbw1IWb8r6OS4OhSt3hPZLkFApLjM8TEXROBuQGLAH2i2gZpcXdLBIrpXuTDhH7Vbm1iXmNGA==
 
+"@types/lodash@^4.14.168":
+  version "4.14.168"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.168.tgz#fe24632e79b7ade3f132891afff86caa5e5ce008"
+  integrity sha512-oVfRvqHV/V6D1yifJbVRU3TMp8OT6o6BG+U9MkwuJ3U8/CsDHvalRpsxBqivn71ztOFZBTfJMvETbqHiaNSj7Q==
+
 "@types/minimatch@3.0.3":
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.3.tgz#3dca0e3f33b200fc7d1139c0cd96c1268cadfd9d"
@@ -4549,7 +4554,7 @@ lodash.sortby@^4.7.0:
   resolved "https://registry.yarnpkg.com/lodash.sortby/-/lodash.sortby-4.7.0.tgz#edd14c824e2cc9c1e0b0a1b42bb5210516a42438"
   integrity sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=
 
-lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19:
+lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.21:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==


### PR DESCRIPTION
- push receipts to wallet state when executing txs
- poll receipt status intermittently for "waitForReceipt"
- get provider balance from server
- get blockheight from server. do a guess & check system of incrementing every 30s (avg blocktime) & verifying it's accurate every 5 min

reliant on: https://github.com/fission-suite/fil-cosigner/pull/18