### PR TITLE
Expiry

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webnative-filecoin",
-  "version": "0.6.5",
+  "version": "0.6.6",
   "description": "Fission Webnative Filecoin SDK",
   "keywords": [],
   "main": "dist/index.cjs.js",

--- a/src/permissions.ts
+++ b/src/permissions.ts
@@ -22,7 +22,7 @@ export const requestCosignPermissionsForDid = async (did: string): Promise<void>
 }
 
 export const rawPermissions = (did: string): RawPermission => ({
-  exp: Date.now() + 60000,
+  exp: Math.floor(Date.now() / 1000) + 3600, // 1hr
   rsc: { 
     cosign: did
   },
@@ -32,3 +32,17 @@ export const rawPermissions = (did: string): RawPermission => ({
     }
   }
 })
+
+export const findUcan = (did: string): string | null => {
+  const wn = setup.getWebnative()
+  const ucan = wn.ucan.dictionary.lookup(`cosign:${did}`)
+  if(!ucan) return null
+  const decoded = wn.ucan.decode(ucan)
+  return wn.ucan.isExpired(decoded) ? null : ucan
+}
+
+export const msTilExpire = (ucan: string): number => {
+  const wn = setup.getWebnative()
+  const decoded = wn.ucan.decode(ucan)
+  return decoded.payload.exp * 1000 - Date.now()
+} 

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -25,7 +25,6 @@ export const server = (update: Partial<ServerVars>): void => {
     ...serverVars,
     ...update
   }
-  console.log('serverVars: ', serverVars)
 }
 
 export const getServerUrl = (): string => {


### PR DESCRIPTION
## Problem
There are no warnings when a ucan expires & it can lead to unexpected behavior

## Solution
- `wallet.ucan` is set to null after expiration
- add a callback with `wallet.onExpire(() => { doSomething() })`
- check the current time till expire `wtih wallet.msTilExpire()`
- I also added `requestPermissions` to wallet, which will keep expiration in sync with wallet state