### PR TITLE
Add ucan spend limit checks

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webnative-filecoin",
-  "version": "0.6.6",
+  "version": "0.6.7",
   "description": "Fission Webnative Filecoin SDK",
   "keywords": [],
   "main": "dist/index.cjs.js",

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,18 +1,18 @@
 import axios from 'axios'
 import { CID } from 'webnative/dist/ipfs'
+import { Ucan } from 'webnative/dist/ucan'
 import { getWebnative, getServerUrl, getServerDid } from './setup'
 import { Address, SignedMessage, MessageBody, WalletInfo, Receipt } from './types'
 
 
-export const cosignMessage = async (message: SignedMessage, prf: string): Promise<Receipt> => {
+export const cosignMessage = async (message: SignedMessage, prf: Ucan): Promise<Receipt> => {
   const wn = getWebnative()
-  const decoded = wn.ucan.decode(prf)
   const ucan = await wn.ucan.build({
     addSignature: true,
     audience: getServerDid(),
-    resource: decoded.payload.rsc,
-    potency: decoded.payload.ptc,
-    proof: prf
+    resource: prf.payload.rsc,
+    potency: prf.payload.ptc,
+    proof: wn.ucan.encode(prf)
   })
   const encoded = wn.ucan.encode(ucan)
   const headers = { Authorization: `Bearer ${encoded}`}


### PR DESCRIPTION
## Problem
We don't check potency of ucans

## Solution
Check ptc to ensure that a UCAN is permissioned for FIL and that the given tx does not exceed the max size

Closes https://github.com/fission-suite/webnative-filecoin/issues/12